### PR TITLE
Fixed incorrect assignment of access address to radio

### DIFF
--- a/nRF51/rbc_mesh/src/radio_control.c
+++ b/nRF51/rbc_mesh/src/radio_control.c
@@ -142,7 +142,7 @@ static void setup_event(radio_event_t* p_evt)
     NRF_RADIO->PACKETPTR = (uint32_t) p_evt->packet_ptr;
     NRF_RADIO->INTENSET = RADIO_INTENSET_END_Msk;
     NRF_RADIO->EVENTS_END = 0;
-    NRF_RADIO->PREFIX1	= ((m_alt_aa >> 24) & 0x000000FF);
+    NRF_RADIO->PREFIX0 |= (((m_alt_aa >> 24) << 8) & 0x0000FF00);
     NRF_RADIO->BASE1    = ((m_alt_aa <<  8) & 0xFFFFFF00);
 
     if (p_evt->event_type == RADIO_EVENT_TYPE_TX)


### PR DESCRIPTION
When looking at mesh data with a BLE sniffer you'll see the advertising address is 0x0041A68F instead of 0xA541A68F. This is due to the mesh using address 1 in the radio, which is composed of BASE1 + PREFIX0.AP1, but radio_init is filling PREFIX1.AP4.